### PR TITLE
Update Mac build instructions in README with OS X 10.10 details

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,66 @@ The following additional packages are required in Ubuntu 10.04
 
 ### Mac
 
-The following additional software is required in the build Mac.
+The following additional software is required in the build Mac:
 
-* `Xcode 5`, [p7zip][1] and [wget][7].
+* Xcode 5
+* [p7zip][1] (required for packaging Qt Creator)
+* [wget][8]
 
 [1]: http://sourceforge.net/projects/p7zip/
-[7]: https://www.gnu.org/software/wget/
+[8]: https://www.gnu.org/software/wget/
+
+To build on OS X 10.10 the following versions of Xcode and Qt are required:
+
+* [Xcode 6.1][9] or later, available on the Mac App Store
+* [Qt 5.4.0][10] or later
+
+[9]: https://itunes.apple.com/fi/app/xcode/id497799835?mt=12
+[10]: http://download.qt.io/archive/qt/5.4/5.4.0/single/
+
+The build Mac should be prepared for command line development. To make sure
+this is the case, please refer to [Technical Note TN2339][11] "Building from
+the Command Line with Xcode FAQ", available in the Apple Mac Developer Library.
+
+[11]: https://developer.apple.com/library/mac/technotes/tn2339/_index.html#//apple_ref/doc/uid/DTS40014588
+
+By default, the build scripts use Qt 5.2.1. To build a different version of Qt,
+set the `QT_SOURCE_PACKAGE` variable in the `buildqt5.sh` script to the name of
+the directory containing the Qt source code, e.g.:
+
+```
+QT_SOURCE_PACKAGE=qt-everywhere-opensource-src-5.4.0
+```
+
+Similarly, when building Qt Creator you need to supply the non-default Qt build
+directory to the `buildqtc.sh` script, e.g.
+
+```
+$ ./buildqtc.sh --qt-dir ~/invariant/qt-everywhere-opensource-src-5.4.0-build
+```
+
+When building p7zip, follow the BUILD instructions in the accompanying README
+file. However, to build p7zip (as of writing version 9.38.1) on OS X 10.10 with
+Xcode 6, the architecture-specific makefile needs to be modified to use the
+correct path for the command line tools. After preparing the makefile with:
+
+```
+$ cp makefile.macosx_llvm_64bits makefile.machine
+```
+
+change the compiler paths in `makefile.machine` from:
+
+```
+CXX=/Developer/usr/bin/llvm-g++
+CC=/Developer/usr/bin/llvm-gcc
+```
+
+to the paths used by Xcode 6 command line tool shims:
+
+```
+CXX=/usr/bin/llvm-g++
+CC=/usr/bin/llvm-gcc
+```
 
 ### Windows
 
@@ -87,4 +141,3 @@ Other build requirements include `perl`, `python` and `ruby` and they are docume
 [5]: http://www.7-zip.org/
 [6]: https://bugreports.qt-project.org/browse/QTBUG-26844
 [7]: http://qt-project.org/doc/qt-5/windows-requirements.html
-

--- a/buildqt5.sh
+++ b/buildqt5.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 #
-# This script build dynamic and static versions of Qt5 into
-# subdirectories in the current dir.
+# This script builds dynamic and static versions of Qt5 into
+# subdirectories in the parent directory of the Qt source directory.
 #
 # Qt5 sources must be found from the current user's home directory
-# $HOME/invariant/qt5 or in case of Windows in C:\invariant\qt5
+# $HOME/invariant/qt-everywhere-opensource-src-5.2.1 or in in case of
+# Windows in C:\invariant\qt-everywhere-opensource-src-5.2.1.
+#
+# To build a version of Qt other than 5.2.1, change the value of the
+# QT_SOURCE_PACKAGE variable.
 #
 # Copyright (C) 2014 Jolla Oy
 # Contact: Juha Kallioinen <juha.kallioinen@jolla.com>
@@ -40,18 +44,20 @@ export LC_ALL=C
 UNAME_SYSTEM=$(uname -s)
 UNAME_ARCH=$(uname -m)
 
+QT_SOURCE_PACKAGE=qt-everywhere-opensource-src-5.2.1
+
 if [[ $UNAME_SYSTEM == "Linux" ]] || [[ $UNAME_SYSTEM == "Darwin" ]]; then
     BASEDIR=$HOME/invariant
-    SRCDIR_QT=$BASEDIR/qt-everywhere-opensource-src-5.2.1
+    SRCDIR_QT=$BASEDIR/$QT_SOURCE_PACKAGE
     # the padding part in the dynamic build directory is necessary in
     # order to accommodate rpath changes at the end of building Qt
     # Creator, which reads Qt resources from this directory.
-    DYN_BUILD_DIR=$BASEDIR/qt-everywhere-opensource-src-5.2.1-build
-    STATIC_BUILD_DIR=$BASEDIR/qt-everywhere-opensource-src-5.2.1-static-build
+    DYN_BUILD_DIR=$BASEDIR/$QT_SOURCE_PACKAGE-build
+    STATIC_BUILD_DIR=$BASEDIR/$QT_SOURCE_PACKAGE-static-build
     ICU_INSTALL_DIR=$BASEDIR/icu-install
 else
     BASEDIR="/c/invariant"
-    SRCDIR_QT="$BASEDIR/qt-everywhere-opensource-src-5.2.1"
+    SRCDIR_QT="$BASEDIR/$QT_SOURCE_PACKAGE"
     BUILD_DIR="$BASEDIR/build-qt5-dynamic-msvc2012"
     ICU_INSTALL_DIR=$BASEDIR/icu
 fi
@@ -72,10 +78,10 @@ build_dynamic_qt_windows() {
 if DEFINED ProgramFiles(x86) set _programs=%ProgramFiles(x86)%
 if Not DEFINED ProgramFiles(x86) set _programs=%ProgramFiles%
 
-set PATH=c:\windows;c:\windows\system32;%_programs\windows kits\8.0\windows performance toolkit;%_programs%\7-zip;C:\invariant\bin;c:\python27;c:\perl\bin;c:\ruby193\bin;c:\invariant\icu\bin;C:\invariant\qt-everywhere-opensource-src-5.2.1\gnuwin32\bin;%_programs%\microsoft sdks\typescript\1.0;c:\windows\system32\wbem;c:\windows\system32\windowspowershell\v1.0;c:\invariant\bin
+set PATH=c:\windows;c:\windows\system32;%_programs\windows kits\8.0\windows performance toolkit;%_programs%\7-zip;C:\invariant\bin;c:\python27;c:\perl\bin;c:\ruby193\bin;c:\invariant\icu\bin;C:\invariant\$QT_SOURCE_PACKAGE\gnuwin32\bin;%_programs%\microsoft sdks\typescript\1.0;c:\windows\system32\wbem;c:\windows\system32\windowspowershell\v1.0;c:\invariant\bin
 call "%_programs%\microsoft visual studio 12.0\vc\vcvarsall.bat"
-call c:\invariant\qt-everywhere-opensource-src-5.2.1\configure.bat $COMMON_CONFIG_OPTIONS -icu -I c:\invariant\icu\include -L c:\invariant\icu\lib -angle -platform win32-msvc2012 -prefix
- 
+call c:\invariant\$QT_SOURCE_PACKAGE\configure.bat $COMMON_CONFIG_OPTIONS -icu -I c:\invariant\icu\include -L c:\invariant\icu\lib -angle -platform win32-msvc2012 -prefix
+
 call jom /j 1
 EOF
 


### PR DESCRIPTION
Updated the Mac section of the `README.md` file with details describing the changes required to successfully build Qt 5 and Qt Creator on OS X 10.10 using Xcode 6 command line tools.

Also added a new variable `QT_SOURCE_PACKAGE` in the `buildqt5.sh` script to make it more convenient to specify which version of Qt to build.