### PR TITLE
buildqtc.sh: Do not fail copying ICU

### DIFF
--- a/buildqtc.sh
+++ b/buildqtc.sh
@@ -316,7 +316,7 @@ build_unix_qtc() {
 
     # Add icu library
     if [[ $UNAME_SYSTEM == "Linux" ]]; then
-        cp $OPT_ICU_PATH/lib/* $QTC_INSTALL_ROOT/lib/qtcreator
+        cp $OPT_ICU_PATH/lib/lib*.so* $QTC_INSTALL_ROOT/lib/qtcreator
     fi
 
 	make bindist_installer


### PR DESCRIPTION
There is a subdirectory in the lib directory, causing 'cp' fail with
"omitting directory" error. Not sure what was the reason for this to
start fail - the directory was there already before, and the command did
not change. Maybe coreutils update? Or newer BASH changed 'set -e'
behavior?