### PR TITLE
Windows: Allow to fallback to opengl sw rendering

### DIFF
--- a/buildqt5.sh
+++ b/buildqt5.sh
@@ -69,7 +69,7 @@ set PATH=c:\windows;c:\windows\system32;%_programs\windows kits\8.0\windows perf
 call "%_programs%\microsoft visual studio 12.0\vc\vcvarsall.bat"
 
 set MAKE=jom
-call $(win_path $DEF_QT_SRC_DIR)\configure.bat -make-tool jom $COMMON_CONFIG_OPTIONS -icu -I $(win_path $DEF_ICU_INSTALL_DIR)\include -L $(win_path $DEF_ICU_INSTALL_DIR)\lib -angle -platform win32-msvc$DEF_MSVC_VER -prefix || exit 1
+call $(win_path $DEF_QT_SRC_DIR)\configure.bat -make-tool jom $COMMON_CONFIG_OPTIONS -icu -I $(win_path $DEF_ICU_INSTALL_DIR)\include -L $(win_path $DEF_ICU_INSTALL_DIR)\lib -opengl dynamic -platform win32-msvc$DEF_MSVC_VER -prefix || exit 1
 
 call jom /j 1 || exit 1
 EOF

--- a/buildqtc.sh
+++ b/buildqtc.sh
@@ -391,6 +391,10 @@ build_windows_qtc() {
 
 	# no more errors allowed
 	set -e
+
+	local opengl32sw_lib="opengl32sw-32.7z"
+	curl -s -f -o $opengl32sw_lib http://$OPT_UPLOAD_HOST/sailfishos/win32-binary-artifacts/opengl/$opengl32sw_lib
+
         # create the build script for windows
 	cat <<EOF > build-windows.bat
 @echo off
@@ -434,6 +438,7 @@ call nmake deployqt || exit 1
 rem copy all the necessary libraries to the install directory
 copy %QTDIR%\bin\libEGL.dll %INSTALL_ROOT%\bin || exit 1
 copy %QTDIR%\bin\libGLESv2*.dll %INSTALL_ROOT%\bin || exit 1
+call 7z x -o%INSTALL_ROOT%\bin $opengl32sw_lib
 copy "%_programs%\microsoft visual studio 12.0\vc\bin\D3Dcompiler_47.dll" %INSTALL_ROOT%\bin || exit 1
 copy "%_programs%\microsoft visual studio 12.0\vc\redist\x86\microsoft.vc120.crt\*.dll" %INSTALL_ROOT%\bin || exit 1
 copy "%_systemdir%\msvc*100.dll" %INSTALL_ROOT%\bin || exit 1


### PR DESCRIPTION
See QTBUG-34964 and QTBUG-41581.

The official Qt build is configured with -opengl dynamic and distributed with opengl32sw.lib, so there should be little if any risk merging this.